### PR TITLE
Treat perltidy error output as failure

### DIFF
--- a/run-perltidy.sh
+++ b/run-perltidy.sh
@@ -20,7 +20,8 @@ if [[ ! -r "${cfg}" ]] && [[ ! -r "$HOME/${cfg}" ]]; then
     opts=("--noprofile" "--perl-best-practices" "${opts[@]}")
 fi
 
-if ! output=$("${cmd}" "${opts[@]}" "$@" 2>&1); then
+if ! output=$("${cmd}" "${opts[@]}" "$@" 2>&1) ||
+   [[ "${output}" == *"## Please see file "*.ERR* ]]; then
     echo "${output}"
     exit 1
 fi


### PR DESCRIPTION
perltidy doesn't exit with nonzero when it outputs to *.ERR, so try scraping its output.