### PR TITLE
Ensure we use an up-to-date Perl::Tidy

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,6 +7,7 @@
 -   id: perltidy
     name: 'perltidy'
     entry: run-perltidy.sh
+    args: [--min-version=20021130]
     files: '\.(pl|pm|t|PL)$'
     language: 'script'
     description: "Runs `perltidy`, requires script in PATH"

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ Add this to your `.pre-commit-config.yaml`
 .perlcriticrc.
 - `perltidy` - Runs `perltidy -pbp -nst -w -b`. Settings can be overridden by
 .perltidyrc.
+
+### Using a minimum version of `perltidy`
+
+Pass `--min-version` as an argument for the perltidy hook.
+
+    - repo: https://github.com/henryykt/pre-commit-perl
+      rev: v0.0.4
+      hooks:
+        - id: perlcritic
+        - id: perltidy
+          args: [--min-version=20190601]

--- a/run-perltidy.sh
+++ b/run-perltidy.sh
@@ -39,7 +39,7 @@ done
 
 # check for minversion
 if ! perl -MPerl::Tidy=${minversion} -e1 >/dev/null 2>&1; then
-    echo "Please update Perl::Tidy to at least verion ${minversion}";
+    echo "Please update Perl::Tidy to at least version ${minversion}";
     exit 1;
 fi
 

--- a/run-perltidy.sh
+++ b/run-perltidy.sh
@@ -8,9 +8,38 @@
 
 set -eu
 
-version=20190601
-if ! perl -MPerl::Tidy=${version} -e1 >/dev/null 2>&1; then
-    echo "Please update Perl::Tidy to at least verion ${version}";
+# default min-version to "oldest we know about"
+# the oldest version on metacpan is 20021130
+minversion=20021130
+
+# bash arguments are ... fun
+# the following came from https://bl.ocks.org/magnetikonline/22c1eb412daa350eeceee76c97519da8
+ARGUMENT_LIST=(
+    "min-version"
+);
+# read arguments
+opts=$(getopt \
+    --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")" \
+    --name "$(basename "$0")" \
+    --options "" \
+    -- "$@"
+)
+eval set --$opts
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --min-version)
+            minversion=$2
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# check for minversion
+if ! perl -MPerl::Tidy=${minversion} -e1 >/dev/null 2>&1; then
+    echo "Please update Perl::Tidy to at least verion ${minversion}";
     exit 1;
 fi
 

--- a/run-perltidy.sh
+++ b/run-perltidy.sh
@@ -8,6 +8,12 @@
 
 set -eu
 
+version=20190601
+if ! perl -MPerl::Tidy=${version} -e1 >/dev/null 2>&1; then
+    echo "Please update Perl::Tidy to at least verion ${version}";
+    exit 1;
+fi
+
 cmd=perltidy
 if ! command -v "${cmd}" >/dev/null 2>&1; then
     echo "This check needs ${cmd} from http://perltidy.sourceforge.net/."


### PR DESCRIPTION
Discovered today that I was sharing a project where I was running
`20190601` and another dev was running `20121207` .. and we were getting
different results from the pre-commit checks