### PR TITLE
Updated used hooks to contemporary versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0
+    rev: v2.3.0
     hooks:
     -   id: check-merge-conflict
     -   id: check-yaml
@@ -9,7 +9,7 @@ repos:
         files: .gitignore
     -   id: trailing-whitespace
 -   repo:  https://github.com/jumanjihouse/pre-commit-hooks
-    sha:   1.8.0
+    rev: 2.1.5
     hooks:
     -   id: shfmt
         args: ['-w', '-i', '4', '-ci']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.0.1
     hooks:
     -   id: check-merge-conflict
     -   id: check-yaml


### PR DESCRIPTION
I just started to use these hooks for Perl and they are work great. I did however notice that your configuration does not use contemporary version of configured hooks.