### PR TITLE
use types perl at perlcritic and perltidy hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,12 +1,14 @@
 -   id: perlcritic
     name: 'perlcritic'
     entry: run-perlcritic.sh
+    types_or: [perl, file]
     files: '\.(pl|pm|t|PL)$'
     language: 'script'
     description: "Runs `perlcritic`, requires script in PATH"
 -   id: perltidy
     name: 'perltidy'
     entry: run-perltidy.sh
+    types_or: [perl, file]
     files: '\.(pl|pm|t|PL)$'
     language: 'script'
     description: "Runs `perltidy`, requires script in PATH"


### PR DESCRIPTION
This PR specifies perl in `types`.

This allows us to determine that the hook is related to perl. For example, this `types` is used[^1] when filtering supported hooks on the official pre-commit site[^2].

Also, the `.t` extension is still used for `files`, since it doesn't seem possible to specify it with `types`[^3].

[^1]:  https://github.com/pre-commit/pre-commit.com/blob/8c10b0f3e0da7d92277a52f5dccb1b0e4f55e6a1/assets/filter_repos.js#L23
[^2]: https://pre-commit.com/hooks.html
[^3]: https://github.com/pre-commit/identify/pull/360