### PR TITLE
make it non-intrusive

### DIFF
--- a/run-perlimports.sh
+++ b/run-perlimports.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Run perlimports on perl scripts.
+# Either with option --inplace-edit or --lint on some files.
 
 set -eu
 
@@ -10,7 +11,29 @@ if ! command -v "${cmd}" >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! output=$("${cmd}" "$@" 2>&1); then
-    echo "${output}"
-    exit 1
-fi
+opts=
+need_cp=
+case $1 in
+    --inplace-edit) opts="$1"; need_cp=1; shift ;;
+    -*) opts="$1"; shift ;;
+esac
+
+for file in "$@"; do
+    if [ -n "${need_cp}" ]; then
+        cp -fp "${file}" "${file}.bak"
+    fi
+    if ! output=$("${cmd}" ${opts} "${file}" 2>&1); then
+        echo "${output}"
+        exit 1
+    fi
+    if [ -n "${need_cp}" ]; then
+        if cmp "$file" "${file}.bak" >/dev/null 2>&1; then
+            # nothing changed
+            mv "${file}.bak" "${file}"
+        else
+            # we have it in git
+            rm -f "${file}.bak"
+        fi
+    fi
+done
+

--- a/run-perltidy.sh
+++ b/run-perltidy.sh
@@ -15,9 +15,11 @@ if ! command -v "${cmd}" >/dev/null 2>&1; then
 fi
 
 cfg=.perltidyrc
-opts=(--nostandard-output --warning-output --backup-and-modify-in-place)
+# --nostandard-output --warning-output --backup-and-modify-in-place --backup-method=move
+opts=(-nst -w -b -bm=move)
 if [[ ! -r "${cfg}" ]] && [[ ! -r "$HOME/${cfg}" ]]; then
-    opts=("--noprofile" "--perl-best-practices" "${opts[@]}")
+    # --noprofile" "--perl-best-practices
+    opts=("-npro" "-pbp" "${opts[@]}")
 fi
 
 if ! output=$("${cmd}" "${opts[@]}" "$@" 2>&1) ||
@@ -25,3 +27,14 @@ if ! output=$("${cmd}" "${opts[@]}" "$@" 2>&1) ||
     echo "${output}"
     exit 1
 fi
+
+for file in "$@"
+do
+    if cmp "$file" "${file}.bak" >/dev/null 2>&1; then
+        # nothing changed
+        mv "${file}.bak" "${file}"
+    else
+        # we have it in git
+        rm -f "${file}.bak"
+    fi
+done


### PR DESCRIPTION
mv back the backup if nothing changed to avoid rebuilds and changed timestamps. no .bak backup since we are on git anyway, analog to the clang-format hook.

with perlimports use cp -p to preserve the timestamp at least.

this avoid endless make - perl Makefile.PL cycles in perl packages, because Makefile.PL is not touched when unchanged.